### PR TITLE
Strip trailing newline from .covignore files

### DIFF
--- a/SublimeRubyCoverage.py
+++ b/SublimeRubyCoverage.py
@@ -93,7 +93,7 @@ class ShowRubyCoverageCommand(sublime_plugin.TextCommand):
         root = find_project_root(self.view.file_name())
         ignore = os.path.join(root, '.covignore')
         if os.path.isfile(ignore):
-            for path in open(ignore).read().split("\n"):
+            for path in open(ignore).read().rstrip("\n").split("\n"):
                 exempt.append(path)
 
         for pattern in exempt:


### PR DESCRIPTION
Should have caught this before the last pull request - I caught a pretty severe bug in .covignore support.

If a .covignore ends in a newline, it gets read as a regexp pattern for an empty string which will, naturally, match every file. Oops!
